### PR TITLE
Fix version of transformers module because the current last version i…

### DIFF
--- a/workshops/ai-workloads-with-huggingface/4 - ITREX - Leveraging Intel Optimizations for Enhanced Inference with Hugging Face.ipynb
+++ b/workshops/ai-workloads-with-huggingface/4 - ITREX - Leveraging Intel Optimizations for Enhanced Inference with Hugging Face.ipynb
@@ -132,7 +132,8 @@
    ],
    "source": [
     "!source /opt/intel/oneapi/setvars.sh #comment out if not running on Intel Developer Cloud Jupyter\n",
-    "!pip install transformers\n",
+    "!pip uninstall transformers -y\n",
+    "!pip install transformers==4.33\n",
     "!pip install intel_extension_for_transformers\n",
     "!pip install tqdm\n",
     "!pip install einops"


### PR DESCRIPTION
This fix is required because current last version of transformes module is not able to build Bloom using Intel Optimization. This fix in the module seems on going, but not yet available.
